### PR TITLE
Ignore Cases when filtering candidates

### DIFF
--- a/company-irony.el
+++ b/company-irony.el
@@ -57,7 +57,7 @@
 
 (defun company-irony--make-all-completions (prefix candidates)
   (cl-loop for candidate in candidates
-           when (string-prefix-p prefix (car candidate))
+           when (string-prefix-p prefix (car candidate) t)
            collect (propertize (car candidate) 'company-irony candidate)))
 
 (defun company-irony--candidates-async (prefix callback)

--- a/company-irony.el
+++ b/company-irony.el
@@ -116,6 +116,7 @@
            (company-irony--irony-candidate arg)))
     (post-completion (company-irony--post-completion
                       (company-irony--irony-candidate arg)))
+    (ignore-case t)
     (sorted t)))
 
 ;;;###autoload


### PR DESCRIPTION
C and C++ has many macros, which is all upper-case, thus I have to hold SHIFT when typing them. It's quite anonying. These commit will ignore cases.
A better solution should provide a `customize-variable` interface to users to let them choose whether to ignore cases or not.
