### PR TITLE
Fix company-irony--get-matching-style

### DIFF
--- a/company-irony.el
+++ b/company-irony.el
@@ -72,7 +72,7 @@ uppercase letters."
 (defun company-irony--get-matching-style ()
   (cl-case company-irony-ignore-case
     (smart 'smart-case)
-    (nil 'exact)
+    ((nil) 'exact)
     (t 'case-insensitive)))
 
 (defun company-irony--candidates (prefix)


### PR DESCRIPTION
`nil `has to be put between parenthesis here to be correctly interpreted as the `nil` symbol